### PR TITLE
Fix OpenAI import and update test

### DIFF
--- a/client/src/App.test.js
+++ b/client/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders app title', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/PastorBuddy/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/server/list-models.js
+++ b/server/list-models.js
@@ -1,6 +1,6 @@
 // list-models.js
 require("dotenv").config();
-const { OpenAI } = require("openai");
+const OpenAI = require("openai");
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,

--- a/server/server.js
+++ b/server/server.js
@@ -6,8 +6,8 @@ dotenv.config();
 console.log("OpenAI Key Loaded:", process.env.OPENAI_API_KEY ? "Yes ✅" : "No ❌");
 // Check if OpenAI API Key is set
 
-// FIX: Import OpenAI correctly
-const { OpenAI } = require("openai");
+// Import OpenAI
+const OpenAI = require("openai");
 
 // Initialize Express
 const app = express();


### PR DESCRIPTION
## Summary
- correct OpenAI imports in server scripts
- update client test to look for the app title

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68541aa348dc8325980dff629959917c